### PR TITLE
switcher to pixel into column/row

### DIFF
--- a/columnRow.js
+++ b/columnRow.js
@@ -1,0 +1,67 @@
+const WIDTH_SETTINGS = {
+  minSizeValueCol: 39,
+  minSizeValuePixel: 370,
+  normalSizeValue: 10,
+  extraSizeValue: 5,
+  extraUnitLocation: [4]
+};
+
+const HEIGHT_SETTINGS = {
+  minSizeValueRow: 12,
+  minSizeValuePixel: 300,
+  normalSizeValue: 20,
+  extraSizeValue: 25,
+  extraUnitLocation: [2, 7]
+};
+
+const getLastNumber = num => +num.toString().slice(+num.toString().length - 1);
+
+const convertWidth = value => {
+  const isExtraValue = getLastNumber(value) === 4 ? WIDTH_SETTINGS.extraSizeValue : 0;
+
+  if (value >= WIDTH_SETTINGS.minSizeValueCol) {
+    let pixelUnit = WIDTH_SETTINGS.minSizeValuePixel + isExtraValue;
+    let colUnit = WIDTH_SETTINGS.minSizeValueCol;
+
+    while (colUnit !== value && Number.isInteger(value)) {
+      ++colUnit;
+
+      if (getLastNumber(colUnit) !== WIDTH_SETTINGS.extraUnitLocation[0]) {
+        pixelUnit += WIDTH_SETTINGS.normalSizeValue;
+      }
+    }
+
+    return pixelUnit || WIDTH_SETTINGS.minSizeValuePixel;
+  } else {
+    return WIDTH_SETTINGS.minSizeValuePixel;
+  }
+};
+
+const convertHeight = value => {
+  if (value >= HEIGHT_SETTINGS.minSizeValueRow) {
+    let pixelUnit = HEIGHT_SETTINGS.minSizeValuePixel;
+    let rowUnit = HEIGHT_SETTINGS.minSizeValueRow;
+
+    while (rowUnit !== value && Number.isInteger(value)) {
+      ++rowUnit;
+
+      if (
+        getLastNumber(rowUnit) !== HEIGHT_SETTINGS.extraUnitLocation[0] &&
+        getLastNumber(rowUnit) !== HEIGHT_SETTINGS.extraUnitLocation[1]
+      ) {
+        pixelUnit += HEIGHT_SETTINGS.normalSizeValue;
+      } else {
+        pixelUnit += HEIGHT_SETTINGS.extraSizeValue;
+      }
+    }
+
+    return pixelUnit || HEIGHT_SETTINGS.minSizeValuePixel;
+  } else {
+    return HEIGHT_SETTINGS.minSizeValuePixel;
+  }
+};
+
+module.exports = {
+  convertWidth,
+  convertHeight
+};

--- a/columnRow.js
+++ b/columnRow.js
@@ -17,7 +17,7 @@ const HEIGHT_SETTINGS = {
 const getLastNumber = num => +num.toString().slice(+num.toString().length - 1);
 
 const convertWidth = value => {
-  const isExtraValue = getLastNumber(value) === 4 ? WIDTH_SETTINGS.extraSizeValue : 0;
+  const isExtraValue = getLastNumber(value) === WIDTH_SETTINGS.extraUnitLocation[0] ? WIDTH_SETTINGS.extraSizeValue : 0;
 
   if (value >= WIDTH_SETTINGS.minSizeValueCol) {
     let pixelUnit = WIDTH_SETTINGS.minSizeValuePixel + isExtraValue;

--- a/index.js
+++ b/index.js
@@ -1,3 +1,5 @@
+const {convertWidth, convertHeight} = require("./columnRow.js");
+
 const CONFIG_KEY = "hyperWindowSize";
 const DEFAULT_WIDTH = 540;
 const DEFAULT_HEIGHT = 380;
@@ -23,7 +25,10 @@ const trySetSize = () => {
 };
 
 module.exports.decorateConfig = config => {
-  if (config[CONFIG_KEY].width || config[CONFIG_KEY].height) {
+  if (config[CONFIG_KEY].transform === true) {
+    width = convertWidth(config[CONFIG_KEY].width) || DEFAULT_WIDTH;
+    height = convertHeight(config[CONFIG_KEY].height) || DEFAULT_HEIGHT;
+  } else if (config[CONFIG_KEY].width || config[CONFIG_KEY].height) {
     width = config[CONFIG_KEY].width || DEFAULT_WIDTH;
     height = config[CONFIG_KEY].height || DEFAULT_HEIGHT;
   }
@@ -32,6 +37,7 @@ module.exports.decorateConfig = config => {
     startX = config[CONFIG_KEY].startX || DEFAULT_POS_X;
     startY = config[CONFIG_KEY].startY || DEFAULT_POS_Y;
   }
+
   trySetSize();
   return config;
 };

--- a/index.js
+++ b/index.js
@@ -26,8 +26,8 @@ const trySetSize = () => {
 
 module.exports.decorateConfig = config => {
   if (config[CONFIG_KEY].transform === true) {
-    width = convertWidth(config[CONFIG_KEY].width) || DEFAULT_WIDTH;
-    height = convertHeight(config[CONFIG_KEY].height) || DEFAULT_HEIGHT;
+    width = convertWidth(config[CONFIG_KEY].width);
+    height = convertHeight(config[CONFIG_KEY].height);
   } else if (config[CONFIG_KEY].width || config[CONFIG_KEY].height) {
     width = config[CONFIG_KEY].width || DEFAULT_WIDTH;
     height = config[CONFIG_KEY].height || DEFAULT_HEIGHT;


### PR DESCRIPTION
For #2 issue.

Turn pixel-units into predefined column/rows sizes. Similar to Windows terminal.

- Inserting `transform: true` in config will enable this feature. 
- _Without `transform` or put `transform: false` is the same thing_.

> Min width: 39
> Min height: 12

_Pixel unit_

![with-pixel](https://user-images.githubusercontent.com/75179881/117589476-20013b00-b100-11eb-9017-26f0f71c56c2.png)

_Columns and rows_

![with-column-and-row](https://user-images.githubusercontent.com/75179881/117589510-5048d980-b100-11eb-8666-dfef107699fa.png)

**Be careful to no forget to put comma at the end**
